### PR TITLE
:id lookup includes new entities in current tx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## WIP
+
+- Allow ID lookup (when creating or referring to new entities with `:id`) to include entities being created in the same transaction
+
 ## [2.3.0] - 2022-03-19
 ### Changed
 - All keywords in the `tg` namespace have been updated to use the `a` namespace. This keeps them short, and makes more sense for the project, which no longer has anything to do with "ThreatGrid".

--- a/src/asami/entities.cljc
+++ b/src/asami/entities.cljc
@@ -174,30 +174,32 @@
                                (if-let [overflow (:overflow (ex-data e))]
                                  (reduced last-result)
                                  (throw e))))
-                           (if (and (seqable? obj)          ; would it be ok performance-wise to turn this into if-let with destructuring to extract e a v to use below instead of (nth ...)?
+                           (if (and (seqable? obj)
                                     (= 4 (count obj))
                                     (= :db/add (first obj)))
-                             (or
-                               ;; Ex.: `[:db/add [:id X] :id X]` that creates a new entity
-                               (when-let [ref (and (writer/lookup-ref? (nth obj 1))
-                                                   (= (first (nth obj 1)) (nth obj 2))
-                                                   (nth obj 1))]
-                                 (let [new-id (or #_(ids ref) (node/new-node graph))] ; I cannot see where `(ids ref)` would be non-nil in any well-formed tx
-                                   [(conj acc (assoc (vec-rest obj) 0 new-id))
-                                    racc
-                                    (assoc ids ref new-id)
-                                    top-ids]))
-                               ;; Ex.: [:db/add -1 :db/id -1]
-                               (when (= (nth obj 2) :db/id)
-                                (let [id (nth obj 3)]
-                                  (when (temp-id? id)
-                                    (let [new-id (or (ids id) (node/new-node graph))]
-                                      [(conj acc (assoc (vec-rest obj) 2 new-id))
-                                       racc
-                                       (assoc ids (or id new-id) new-id)
-                                       top-ids]))))
-                              (let [triple (mapv #(or (ids %) (ref->id %)) (rest obj))]
-                                [(conj acc triple) racc ids top-ids]))
+                             (let [entity (nth obj 1)
+                                   attribute (nth obj 2)]
+                               (or
+                                 ;; Ex.: `[:db/add [:id X] :id X]` that creates a new entity
+                                 (when-let [ref (and (writer/lookup-ref? entity)
+                                                     (= (first entity) attribute)
+                                                     entity)]
+                                   (let [new-id (or (ids ref) (node/new-node graph))]
+                                     [(conj acc (assoc (vec-rest obj) 0 new-id))
+                                      racc
+                                      (assoc ids ref new-id)
+                                      top-ids]))
+                                 ;; Ex.: [:db/add -1 :db/id -1]
+                                 (when (= attribute :db/id)
+                                   (let [id (nth obj 3)]
+                                     (when (temp-id? id)
+                                       (let [new-id (or (ids id) (node/new-node graph))]
+                                         [(conj acc (assoc (vec-rest obj) 2 new-id))
+                                          racc
+                                          (assoc ids (or id new-id) new-id)
+                                          top-ids]))))
+                                 (let [triple (mapv #(or (ids %) (ref->id %)) (rest obj))]
+                                   [(conj acc triple) racc ids top-ids])))
                              (throw (ex-info (str "Bad data in transaction: " obj) {:data obj}))))))
          [triples rtriples id-map top-level-ids] (reduce add-triples [[] retractions {} #{}] new-data)
          triples (writer/backtrack-unlink-top-entities top-level-ids triples)]

--- a/src/asami/entities/writer.cljc
+++ b/src/asami/entities/writer.cljc
@@ -80,9 +80,9 @@
     :a/empty-list))
 
 (defn lookup-ref?
-  "Tests if i is a lookup ref"
+  "Tests if i is a lookup ref. Similar to https://blog.datomic.com/2014/02/datomic-lookup-refs.html"
   [i]
-  (and (vector? i) (= 2 (count i)) (#{:db/id :db/ident :id} (first i))))
+  (and (vector? i) (= 2 (count i)) (keyword? (first i))))
 
 (defn resolve-ref
   [[prop id]]

--- a/src/asami/entities/writer.cljc
+++ b/src/asami/entities/writer.cljc
@@ -82,7 +82,7 @@
 (defn lookup-ref?
   "Tests if i is a lookup ref"
   [i]
-  (and (vector? i) (keyword? (first i)) (= 2 (count i))))
+  (and (vector? i) (= 2 (count i)) (#{:db/id :db/ident :id} (first i))))
 
 (defn resolve-ref
   [[prop id]]

--- a/test/asami/api_test.cljc
+++ b/test/asami/api_test.cljc
@@ -217,7 +217,8 @@
       (is (= {:person/name "Betty" :person/age 43} betty)))))
 
 (deftest test-db-add-with-lookup-ref-creates-entity
-  (let [{d :db-after} @(transact *conn* {:tx-data [[:db/add [:id "bobid"] :id "bobid"]
+  (let [c (connect "asami:mem://testlrce")
+        {d :db-after} @(transact c {:tx-data [[:db/add [:id "bobid"] :id "bobid"]
                                                    [:db/add [:id "bobid"] :person/name "Bob"]
                                                    [:db/add [:id "bobid"] :person/age 42]
 

--- a/test/asami/api_test.cljc
+++ b/test/asami/api_test.cljc
@@ -908,3 +908,8 @@
              {:person/name "Person"})))))
 
 #?(:cljs (run-tests))
+
+(comment
+  ;; Delete all test DBs so that tests can be re-run with a fresh slate
+  (doseq [url (keys @a/connections)]
+    (a/delete-database url)))


### PR DESCRIPTION
Allow ID lookup (when creating or referring to new entities with `:id`) to include entities being created in the same transaction. It solves the following problem:

> I struggle to understand what is the correct way to 1. create a new entity and 2. link an existing entity to it. For the link I cannot use the new entity's `:id` as a lookup ref because it is not created yet and I do not have any other ID (since I cannot use `:db/id -1` together with specifying a custom `:id`). It is demonstrated by the following failing test:

```clojure
(deftest existing-add-ref-to-new
  @(d/transact *conn* {:tx-data [{:id "existing"}]})
  @(d/transact *conn* {:tx-data [{:id "new"}
                                 [:db/add [:id "existing"] :ref [:id "new"]]]})
  ; BROKEN: Resolving the lookup ref does not work, it is stored as-is - likely b/c the entity cannot be looked up
  ;         since we are only just creating it
  (is (= {:id "existing",
          :ref {:id "new"}}
         (d/entity (d/db *conn*) "existing"))))
; => Expected {... :ref {:id "new"}}, Actual {... :ref [:id "new"]}
```

## NOTE

The 2nd commit 42aa2e01865094d590707583bef3e960b0cb6a51 refactors tests to make it possible to re-run them in the REPL without them failing due to left-over state from a previous run. It can/should be reviewed separately from the rest.