### PR TITLE
Graph sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A graph database, for Clojure and ClojureScript.
 
-The latest version is :
+The latest version is:
 
 [![Clojars Project](http://clojars.org/org.clojars.quoll/asami/latest-version.svg)](http://clojars.org/org.clojars.quoll/asami)
 
@@ -330,7 +330,7 @@ The command will also work on `local` stores, which means that they can be loade
 ## License
 
 Copyright © 2016-2021 Cisco Systems
-Copyright © 2015-2021 Paula Gearon
+Copyright © 2015-2022 Paula Gearon
 
 Portions of src/asami/cache.cljc are Copyright © Rich Hickey
 

--- a/src/asami/analytics.cljc
+++ b/src/asami/analytics.cljc
@@ -18,7 +18,7 @@
 (s/defn subgraph-from-node :- #{s/Any}
   "Finds a single subgraph for an index graph. Returns all entity IDs that appear
    in the same subgraph as the provided node."
-  [{:keys [spo osp] :as graph} :- GraphType
+  [{:keys [spo pos] :as graph} :- GraphType
    node :- s/Any]
   (let [get-object-sets-fn (lowest-level-sets-fn graph)]
     (letfn [(next-nodes [seen n]
@@ -26,7 +26,8 @@
                                     (->> (spo n) vals get-object-sets-fn (apply set/union))
                                     seen)
                     down-connected-entities (set/select entity-node? down-connected)
-                    up-connected (->> (osp n) keys (remove seen) set)]
+                    ;up-connected (->> (osp n) keys (remove seen) set)
+                    up-connected (->> (vals pos) (map #(get % n)) (mapcat keys) (remove seen) set)]
                 (set/union down-connected-entities up-connected)))]
       (loop [nodes #{node} seen #{node}]
         (if-not (seq nodes)

--- a/src/asami/durable/block/bufferblock.clj
+++ b/src/asami/durable/block/bufferblock.clj
@@ -58,15 +58,15 @@
         arr))
 
     (put-byte! [this offset v]
-      (.put ^ByteBuffer bb (+ byte-offset offset) v)
+      (.put ^ByteBuffer bb ^int (+ byte-offset offset) ^byte v)
       this)
 
     (put-int! [this offset v]
-      (.put ^IntBuffer ib (+ int-offset offset) v)
+      (.put ^IntBuffer ib ^int (+ int-offset offset) ^int v)
       this)
 
     (put-long! [this offset v]
-      (.put ^LongBuffer lb (+ long-offset offset) v)
+      (.put ^LongBuffer lb ^int (+ long-offset offset) ^long v)
       this)
 
     ;; a single writer allows for position/put

--- a/src/asami/durable/graph.cljc
+++ b/src/asami/durable/graph.cljc
@@ -120,6 +120,11 @@
               (log/trace "resolving [" s " " p " " o "]")
               (get-from-index this s p o)))))))
 
+  (attribute-values
+    [this node]
+    (if-let [s (find-id pool node)]
+      (get-from-index this s '?a '?v)))
+  
   (count-triple
     [this subj pred obj]
     (let [[plain-pred trans-tag] (common-index/check-for-transitive pred)

--- a/src/asami/entities/reader.cljc
+++ b/src/asami/entities/reader.cljc
@@ -3,6 +3,7 @@
     asami.entities.reader
   (:require [asami.entities.general :as general :refer [tg-ns KeyValue EntityMap GraphType]]
             [zuko.node :as node]
+            [asami.graph :as graph]
             [schema.core :as s :refer [=>]]
             [clojure.string :as string]))
 
@@ -25,7 +26,7 @@
   "Return all the property/value pairs for a given entity in the store. "
   [graph :- GraphType
    entity :- s/Any]
-  (->> (node/find-triple graph [entity '?p '?o])
+  (->> (graph/attribute-values graph entity)
        (remove #(= :tg/owns (first %)))))
 
 

--- a/src/asami/graph.cljc
+++ b/src/asami/graph.cljc
@@ -18,6 +18,7 @@
     "Bulk operation to add and remove multiple statements in a single operation")
   (graph-diff [this other] "Returns all subjects that have changed in this graph, compared to other")
   (resolve-triple [this subj pred obj] "Resolves patterns from the graph, and returns unbound columns only")
+  (attribute-values [this node] "Returns all predicate/objects or attribute/values for a node")
   (count-triple [this subj pred obj] "Resolves patterns from the graph, and returns the size of the resolution"))
 
 (def GraphType (s/pred #(satisfies? Graph %1)))

--- a/src/asami/multi_graph.cljc
+++ b/src/asami/multi_graph.cljc
@@ -149,6 +149,8 @@ allow rules to successfully use this graph type."
     (if-let [[plain-pred trans-tag] (common/check-for-transitive pred)]
       (common/get-transitive-from-index this trans-tag subj plain-pred obj)
       (get-from-multi-index this subj pred obj)))
+  (attribute-values [this node]
+    (get-from-multi-index this node '?a '?v))
   (count-triple [this subj pred obj] ;; This intentionally ignores multi-edges, and is used for Naga
     (if-let [[plain-pred trans-tag] (common/check-for-transitive pred)]
       (count-transitive-from-index this trans-tag subj plain-pred obj)

--- a/src/asami/seqgraph.cljc
+++ b/src/asami/seqgraph.cljc
@@ -1,0 +1,101 @@
+(ns ^{:doc "An graph wrapper for seqs"
+      :author "Paula Gearon"}
+    asami.seqgraph
+  (:require [asami.graph :as gr :refer [Graph graph-add graph-delete graph-diff resolve-triple count-triple]]
+            [asami.common-index :as common :refer [? NestedIndex]]
+            [asami.analytics :as analytics]
+            [zuko.node :refer [NodeAPI]]
+            [zuko.logging :as log :include-macros true]
+            [schema.core :as s :include-macros true]))
+
+(defmulti get-from-index
+  "Lookup an index in the graph for the requested data.
+   Returns a sequence of unlabelled bindings. Each binding is a vector of binding values."
+  common/simplify)
+
+(defmethod get-from-index [:v :v :v]
+  [data s p o]
+  (if (some (fn [[a b c]] (and (= s a) (= p b) (= o c))) data) [[]] []))
+
+(defmethod get-from-index [:v :v  ?]
+  [data s p o]
+  (sequence
+   (comp
+    (filter (fn [[a b _]] (and (= s a) (= p b))))
+    (map #(subvec % 2 3)))
+   data))
+
+(defmethod get-from-index [:v  ? :v]
+  [data s p o]
+  (sequence
+   (comp
+    (filter (fn [[a _ c]] (and (= s a) (= o c))))
+    (map #(subvec % 1 2)))
+   data))
+
+(defmethod get-from-index [:v  ?  ?]
+  [data s p o]
+  (sequence
+   (comp
+    (filter (fn [[a _ _]] (= a s)))
+    (map #(subvec % 1 3)))
+   data))
+
+(defmethod get-from-index [ ? :v :v]
+  [data s p o]
+  (sequence
+   (comp
+    (filter (fn [[_ b c]] (and (= p b) (= o c))))
+    (map #(subvec % 0 1)))
+   data))
+
+(defmethod get-from-index [ ? :v  ?]
+  [data s p o]
+  (sequence
+   (comp
+    (filter (fn [[_ b _]] (= b p)))
+    (map #(vector (first %) (nth % 2))))
+   data))
+
+(defmethod get-from-index [ ?  ? :v]
+  [data s p o]
+  (sequence
+   (comp
+    (filter (fn [[_ _ c]] (= c o)))
+    (map #(subvec % 0 2)))
+   data))
+
+(defmethod get-from-index [ ?  ?  ?]
+  [data s p o]
+  (map #(subvec % 0 3) data))
+
+
+(declare empty-graph)
+
+(defrecord GraphSeq [data]
+  Graph
+  (new-graph [this] empty-graph)
+  (graph-add [this subj pred obj]
+    (graph-add this subj pred obj gr/*default-tx-id*))
+  (graph-add [this subj pred obj tx]
+    (log/trace "insert: " [subj pred obj tx])
+    (update this :data conj [subj pred obj tx]))
+  (graph-delete [this subj pred obj]
+    (log/trace "delete " [subj pred obj])
+    (update this :data #(remove (fn [[s p o]] (and (= subj s) (= pred p) (= obj o))) %)))
+  (graph-transact [this tx-id assertions retractions]
+    (throw (ex-info "Unsupported operation" {:operation :graph-transact})))
+  (graph-transact [this tx-id assertions retractions generated-data]
+    (throw (ex-info "Unsupported operation" {:operation :graph-transact})))
+  (graph-diff [this other]
+    (throw (ex-info "Unsupported operation" {:operation :graph-diff})))
+  (resolve-triple [this subj pred obj]
+    (if-let [[plain-pred trans-tag] (common/check-for-transitive pred)]
+      (throw (ex-info "Unsupported operation" {:operation :transitive-resolve-triple}))
+      (get-from-index data subj pred obj)))
+  (count-triple [this subj pred obj]
+    (count (resolve-triple this subj pred obj))))
+
+(def empty-graph (->GraphSeq []))
+
+(defn new-graph [data] (->GraphSeq data))

--- a/src/asami/seqgraph.cljc
+++ b/src/asami/seqgraph.cljc
@@ -8,6 +8,13 @@
             [zuko.logging :as log :include-macros true]
             [schema.core :as s :include-macros true]))
 
+(defn subseq
+  "A subvec wrapper that drops back to sequences when the seq is not a vector"
+  [v a b]
+  (if (vector? v)
+    (subvec v a b)
+    (drop a (take b v))))
+
 (defmulti get-from-index
   "Lookup an index in the graph for the requested data.
    Returns a sequence of unlabelled bindings. Each binding is a vector of binding values."
@@ -22,7 +29,7 @@
   (sequence
    (comp
     (filter (fn [[a b _]] (and (= s a) (= p b))))
-    (map #(subvec % 2 3)))
+    (map #(subseq % 2 3)))
    data))
 
 (defmethod get-from-index [:v  ? :v]
@@ -30,7 +37,7 @@
   (sequence
    (comp
     (filter (fn [[a _ c]] (and (= s a) (= o c))))
-    (map #(subvec % 1 2)))
+    (map #(subseq % 1 2)))
    data))
 
 (defmethod get-from-index [:v  ?  ?]
@@ -38,7 +45,7 @@
   (sequence
    (comp
     (filter (fn [[a _ _]] (= a s)))
-    (map #(subvec % 1 3)))
+    (map #(subseq % 1 3)))
    data))
 
 (defmethod get-from-index [ ? :v :v]
@@ -46,7 +53,7 @@
   (sequence
    (comp
     (filter (fn [[_ b c]] (and (= p b) (= o c))))
-    (map #(subvec % 0 1)))
+    (map #(subseq % 0 1)))
    data))
 
 (defmethod get-from-index [ ? :v  ?]
@@ -62,12 +69,12 @@
   (sequence
    (comp
     (filter (fn [[_ _ c]] (= c o)))
-    (map #(subvec % 0 2)))
+    (map #(subseq % 0 2)))
    data))
 
 (defmethod get-from-index [ ?  ?  ?]
   [data s p o]
-  (map #(subvec % 0 3) data))
+  (map #(subseq % 0 3) data))
 
 
 (declare empty-graph)

--- a/src/asami/seqgraph.cljc
+++ b/src/asami/seqgraph.cljc
@@ -2,18 +2,11 @@
       :author "Paula Gearon"}
     asami.seqgraph
   (:require [asami.graph :as gr :refer [Graph graph-add graph-delete graph-diff resolve-triple count-triple]]
-            [asami.common-index :as common :refer [? NestedIndex]]
+            [asami.common-index :as common :refer [? NestedIndex subvseq]]
             [asami.analytics :as analytics]
             [zuko.node :refer [NodeAPI]]
             [zuko.logging :as log :include-macros true]
             [schema.core :as s :include-macros true]))
-
-(defn subseq
-  "A subvec wrapper that drops back to sequences when the seq is not a vector"
-  [v a b]
-  (if (vector? v)
-    (subvec v a b)
-    (drop a (take b v))))
 
 (defmulti get-from-index
   "Lookup an index in the graph for the requested data.
@@ -29,7 +22,7 @@
   (sequence
    (comp
     (filter (fn [[a b _]] (and (= s a) (= p b))))
-    (map #(subseq % 2 3)))
+    (map #(subvseq % 2 3)))
    data))
 
 (defmethod get-from-index [:v  ? :v]
@@ -37,7 +30,7 @@
   (sequence
    (comp
     (filter (fn [[a _ c]] (and (= s a) (= o c))))
-    (map #(subseq % 1 2)))
+    (map #(subvseq % 1 2)))
    data))
 
 (defmethod get-from-index [:v  ?  ?]
@@ -45,7 +38,7 @@
   (sequence
    (comp
     (filter (fn [[a _ _]] (= a s)))
-    (map #(subseq % 1 3)))
+    (map #(subvseq % 1 3)))
    data))
 
 (defmethod get-from-index [ ? :v :v]
@@ -53,7 +46,7 @@
   (sequence
    (comp
     (filter (fn [[_ b c]] (and (= p b) (= o c))))
-    (map #(subseq % 0 1)))
+    (map #(subvseq % 0 1)))
    data))
 
 (defmethod get-from-index [ ? :v  ?]
@@ -69,12 +62,12 @@
   (sequence
    (comp
     (filter (fn [[_ _ c]] (= c o)))
-    (map #(subseq % 0 2)))
+    (map #(subvseq % 0 2)))
    data))
 
 (defmethod get-from-index [ ?  ?  ?]
   [data s p o]
-  (map #(subseq % 0 3) data))
+  (map #(subvseq % 0 3) data))
 
 
 (declare empty-graph)

--- a/src/asami/wrapgraph.cljc
+++ b/src/asami/wrapgraph.cljc
@@ -1,0 +1,192 @@
+(ns ^{:doc "An graph wrapper for seqs"
+      :author "Paula Gearon"}
+    asami.wrapgraph
+  (:require [asami.graph :as gr :refer [Graph graph-add graph-delete graph-diff resolve-triple count-triple]]
+            [asami.common-index :as common :refer [? NestedIndex]]
+            [asami.analytics :as analytics]
+            [zuko.node :refer [NodeAPI]]
+            [zuko.logging :as log :include-macros true]
+            [schema.core :as s :include-macros true]))
+
+(def ^:const TX-LOGGING "asami.tx.logging")
+
+(defmulti get-from-index
+  "Lookup an index in the graph for the requested data.
+   Returns a sequence of unlabelled bindings. Each binding is a vector of binding values."
+  common/simplify)
+
+(defmethod get-from-index [:v :v :v]
+  [data s p o]
+  (if (some (fn [[a b c]] (and (= s a) (= p b) (= o c))) data) [[]] []))
+
+(defmethod get-from-index [:v :v  ?]
+  [data s p o]
+  (sequence
+   (comp
+    (filter (fn [[a b _]] (and (= s a) (= p b))))
+    (map #(subseq % 2 3)))
+   data))
+
+(defmethod get-from-index [:v  ? :v]
+  [data s p o]
+  (sequence
+   (comp
+    (filter (fn [[a _ c]] (and (= s a) (= o c))))
+    (map #(subseq % 1 2)))
+   data))
+
+(defmethod get-from-index [:v  ?  ?]
+  [data s p o]
+  (sequence
+   (comp
+    (filter (fn [[a _ _]] (= a s)))
+    (map #(subseq % 1 3)))
+   data))
+
+(defmethod get-from-index [ ? :v :v]
+  [data s p o]
+  (sequence
+   (comp
+    (filter (fn [[_ b c]] (and (= p b) (= o c))))
+    (map #(subseq % 0 1)))
+   data))
+
+(defmethod get-from-index [ ? :v  ?]
+  [data s p o]
+  (sequence
+   (comp
+    (filter (fn [[_ b _]] (= b p)))
+    (map #(vector (first %) (nth % 2))))
+   data))
+
+(defmethod get-from-index [ ?  ? :v]
+  [data s p o]
+  (sequence
+   (comp
+    (filter (fn [[_ _ c]] (= c o)))
+    (map #(subseq % 0 2)))
+   data))
+
+(defmethod get-from-index [ ?  ?  ?]
+  [data s p o]
+  (map #(subseq % 0 3) data))
+
+(defn exists?
+  "Fast lookup for a statement in an index/graph"
+  [graph s p o]
+  (some-> (:spo graph) s p o))
+
+(defn graphs-equiv?
+  "Checks if two GraphWrapper instances are equivalent"
+  [g1 g2]
+  (and (identical? (:addgraph g1) (:addgraph g2))
+       (identical? (:delgraph g1) (:delgraph g2))))
+
+(defn graph-subtract
+  [a b]
+  (reduce (fn [g [s p o]] (gr/delete g s p o)) a (gr/resolve-triple b ?s ?p ?o)))
+
+(defrecord GraphWrapper [addgraph delgraph wrapped-graph tx-logging]
+  Graph
+  (new-graph [this] (gr/new-graph wrapped-graph))
+
+  (graph-add [this subj pred obj]
+    (graph-add this subj pred obj gr/*default-tx-id*))
+
+  (graph-add [this subj pred obj tx]
+    (log/trace "wrap insert: " [subj pred obj tx])
+    (if (seq (gr/resolve-triple delgraph subj pred obj))
+      ;; deleted statements can just be undeleted. They keep their old statement ID
+      (assoc this :delgraph (gr/graph-delete delgraph subj pred obj))
+      ;; only check if a statement exists if transactions are being logged
+      (if (and tx-logging (seq (gr/resolve-triple wrapped-graph subj pred obj)))
+        ;; the statement exists in the wrapped storage. Don't reinsert
+        this
+        ;; add the statement to in-memory storage
+        (assoc this :addgraph (gr/graph-add addgraph subj pred obj tx)))))
+
+  (graph-delete [this subj pred obj]
+    (log/trace "delete " [subj pred obj])
+    (if (seq (gr/resolve-triple addgraph subj pred obj))
+      ;; added statements can be removed from the in-memory graph
+      (assoc this :addgraph (gr/graph-delete addgraph subj pred obj))
+      ;; only check if a statement already exists if transactions are being logged
+      (if (and tx-logging (seq (gr/resolve-triple wrapped-graph subj pred obj)))
+        ;; the statement does not exist in wrapped storage. Don't retract it.
+        this
+        ;; remove the statement from in-memory storage. TX ids are not relevant on the delgraph
+        (assoc this :delgraph (gr/graph-add delgraph subj pred obj nil)))))
+
+  (graph-transact [this tx-id assertions retractions]
+    (gr/graph-transact this tx-id assertions retractions (volatile! [[] [] {}])))
+
+  (graph-transact
+    [this tx-id assertions retractions generated-data]
+    (let [[a r] @generated-data
+          asserts (transient a)
+          retracts (transient r)
+          change-graph (fn [gr rm-key add-key]
+                         (fn [acc [s p o]]
+                           (if (exists? gr s p o)
+                             (assoc acc rm-key (gr/graph-delete (rm-key acc) s p o))
+                             (assoc acc add-key (gr/graph-add (add-key acc) s p o tx-id)))))
+          graph-remove (change-graph addgraph :addgraph :delgraph)
+          graph-add (change-graph delgraph :delgraph :addgraph)
+          new-graph-del (reduce (if tx-logging
+                                  graph-remove
+                                  (fn [acc [s p o]]
+                                    (let [aa (graph-remove acc s p o)]
+                                      (when-not (graphs-equiv? aa acc)
+                                        (conj! asserts (->Datom s p o tx-id false)))
+                                      aa)))
+                                this retractions)
+          new-graph (reduce (if tx-logging
+                              graph-add
+                              (fn [acc [s p o]]
+                                (let [aa (graph-add acc s p o)]
+                                  (when-not (graphs-equiv? aa acc)
+                                    (conj! asserts (->Datom s p o tx-id true)))
+                                  aa)))
+                            new-graph-del assertions)]
+      (vreset! generated-data (if tx-logging
+                                [(persistent! asserts) (persistent! retracts)]
+                                [(map (fn [[s p o]] (->Datom s p o true)) assertions)
+                                 (map (fn [[s p o]] (->Datom s p o false)) retractions)]))
+      new-graph))
+
+  (graph-diff [this other]
+    (if (= other wrappedgraph)
+      (merge-graphs addgraph delgraph)
+      (throw (ex-info "Unsupported operation" {:operation :graph-diff}))))
+
+  (resolve-triple [this subj pred obj]
+    (if-let [[plain-pred trans-tag] (common/check-for-transitive pred)]
+      ;; TODO: this is very important to add
+      (throw (ex-info "Unsupported operation" {:operation :transitive-resolve-triple}))
+      (let [removed? (set (resolve-triple delgraph subj pred obj))]
+        (concat
+         (resolve-triple addgraph subj pred obj)
+         (remove removed? (resolve-triple wrapped-graph subj pred obj))))))
+
+  (count-triple [this subj pred obj]
+    (- (+ (count (resolve-triple wrapped-graph subj pred obj))
+          (count (resolve-triple addgraph subj pred obj)))
+       (count (resolve-triple delgraph subj pred obj)))))
+
+(defn get-logging
+  []
+  #?(:clj (some->> (System/getProperty TX-LOGGING) str/lower-case (= "true"))
+     :cljs nil))
+
+(defn wrap-graph
+  "Wraps a given graph with in-memory operations"
+  [existing-graph]
+  (->GraphSeq (mem/new-graph) (mem/new-graph)
+              (get-logging) existing-graph))
+
+(defn unwrap-graph
+  "Merges a wrapped graph with the in-memory data used to wrap it."
+  [{:keys [addgraph delgraph wrapped-graph tx-logging] :as graph}]
+  (gr/graph-transact wrapped-graph
+                     (gr/resolve-triple addgraph '?s '?p '?o)
+                     (gr/resolve-triple delgraph '?s '?p '?o)))

--- a/src/asami/wrapgraph.cljc
+++ b/src/asami/wrapgraph.cljc
@@ -27,7 +27,7 @@
   (sequence
    (comp
     (filter (fn [[a b _]] (and (= s a) (= p b))))
-    (map #(subseq % 2 3)))
+    (map #(subvseq % 2 3)))
    data))
 
 (defmethod get-from-index [:v  ? :v]
@@ -35,7 +35,7 @@
   (sequence
    (comp
     (filter (fn [[a _ c]] (and (= s a) (= o c))))
-    (map #(subseq % 1 2)))
+    (map #(subvseq % 1 2)))
    data))
 
 (defmethod get-from-index [:v  ?  ?]
@@ -43,7 +43,7 @@
   (sequence
    (comp
     (filter (fn [[a _ _]] (= a s)))
-    (map #(subseq % 1 3)))
+    (map #(subvseq % 1 3)))
    data))
 
 (defmethod get-from-index [ ? :v :v]
@@ -51,7 +51,7 @@
   (sequence
    (comp
     (filter (fn [[_ b c]] (and (= p b) (= o c))))
-    (map #(subseq % 0 1)))
+    (map #(subvseq % 0 1)))
    data))
 
 (defmethod get-from-index [ ? :v  ?]
@@ -67,12 +67,12 @@
   (sequence
    (comp
     (filter (fn [[_ _ c]] (= c o)))
-    (map #(subseq % 0 2)))
+    (map #(subvseq % 0 2)))
    data))
 
 (defmethod get-from-index [ ?  ?  ?]
   [data s p o]
-  (map #(subseq % 0 3) data))
+  (map #(subvseq % 0 3) data))
 
 (defn exists?
   "Fast lookup for a statement in an index/graph"

--- a/test/asami/memory_index_test.cljc
+++ b/test/asami/memory_index_test.cljc
@@ -89,21 +89,17 @@
               (assert-data (take 2 data) 1)
               (assert-data (drop 2 data) 2))
         last-stmt-id (count data)]
-    (is (= (inc last-stmt-id) (:next-stmt-id g)))
+    (is (= last-stmt-id (count (:spot g))))
     ;; TODO use actual queries instead once they're supported
     (is (= 1 (get-in g [:spo :a :p1 :y :t])))
-    (is (= 1 (get-in g [:osp :y :a :p1 :t])))
     (is (= 1 (get-in g [:pos :p1 :y :a :t])))
 
     (is (= 2 (get-in g [:spo :c :p4 :t :t])))
-    (is (= 2 (get-in g [:osp :t :c :p4 :t])))
     (is (= 2 (get-in g [:pos :p4 :t :c :t])))
 
     (is (= 1 (get-in g [:spo :a :p1 :x :id])))
-    (is (= 1 (get-in g [:osp :x :a :p1 :id])))
     (is (= 1 (get-in g [:pos :p1 :x :a :id])))
 
     (is (= last-stmt-id (get-in g [:spo :c :p4 :t :id])))
-    (is (= last-stmt-id (get-in g [:osp :t :c :p4 :id])))
     (is (= last-stmt-id (get-in g [:pos :p4 :t :c :id])))))
 

--- a/test/asami/seqgraph_test.cljc
+++ b/test/asami/seqgraph_test.cljc
@@ -61,6 +61,9 @@
 (deftest test-wrap
   (do-load-test (new-graph data)))
 
+(deftest test-wrap-seqs
+  (do-load-test (new-graph (map list* data))))
+
 (deftest test-count
   (let [g (assert-data empty-graph data)
         r1 (count-pattern g '[:a ?a ?b])

--- a/test/asami/seqgraph_test.cljc
+++ b/test/asami/seqgraph_test.cljc
@@ -1,0 +1,86 @@
+(ns asami.seqgraph-test
+  (:require [asami.graph :refer [graph-add resolve-pattern count-pattern]]
+     [asami.seqgraph :refer [empty-graph new-graph]]
+     [schema.test :as st :refer [deftest] :refer-macros [deftest]]
+     [clojure.test :as t :refer [testing is run-tests] :refer-macros [testing is run-tests]]))
+
+(t/use-fixtures :once st/validate-schemas)
+
+(def data
+  [[:a :p1 :x]
+   [:a :p1 :y]
+   [:a :p2 :z]
+   [:a :p3 :x]
+   [:b :p1 :x]
+   [:b :p2 :x]
+   [:b :p3 :z]
+   [:c :p4 :t]])
+
+(defn assert-data
+  ([g d]
+   (assert-data g d 1))
+  ([g d tx]
+   (reduce (fn [g [s p o]] (graph-add g s p o tx)) g d)))
+
+(defn unordered-resolve
+  [g pattern]
+  (into #{} (resolve-pattern g pattern)))
+
+(defn do-load-test
+  [g]
+  (let [r1 (unordered-resolve g '[:a ?a ?b])
+        r2 (unordered-resolve g '[?a :p2 ?b])
+        r3 (unordered-resolve g '[:a :p1 ?a])
+        r4 (unordered-resolve g '[?a :p2 :z])
+        r5 (unordered-resolve g '[:a ?a :x])
+        r6 (unordered-resolve g '[:a :p4 ?a])
+        r6' (unordered-resolve g '[:a :p3 ?a])
+        r7 (unordered-resolve g '[:a :p1 :x])
+        r8 (unordered-resolve g '[:a :p1 :b])
+        r9 (unordered-resolve g '[?a ?b ?c])]
+    (is (= #{[:p1 :x]
+             [:p1 :y]
+             [:p2 :z]
+             [:p3 :x]} r1))
+    (is (= #{[:a :z]
+             [:b :x]} r2))
+    (is (= #{[:x]
+             [:y]} r3))
+    (is (= #{[:a]} r4))
+    (is (= #{[:p1]
+             [:p3]} r5))
+    (is (empty? r6))
+    (is (= #{[:x]} r6'))
+    (is (= #{[]} r7))
+    (is (empty? r8))
+    (is (= (into #{} data) r9))))
+
+(deftest test-load
+  (do-load-test (assert-data empty-graph data)))
+
+(deftest test-wrap
+  (do-load-test (new-graph data)))
+
+(deftest test-count
+  (let [g (assert-data empty-graph data)
+        r1 (count-pattern g '[:a ?a ?b])
+        r2 (count-pattern g '[?a :p2 ?b])
+        r3 (count-pattern g '[:a :p1 ?a])
+        r4 (count-pattern g '[?a :p2 :z])
+        r5 (count-pattern g '[:a ?a :x])
+        r6 (count-pattern g '[:a :p4 ?a])
+        r7 (count-pattern g '[:a :p1 :x])
+        r8 (count-pattern g '[:a :p1 :b])
+        r9 (count-pattern g '[?a ?b ?c])]
+    (is (= 4 r1))
+    (is (= 2 r2))
+    (is (= 2 r3))
+    (is (= 1 r4))
+    (is (= 2 r5))
+    (is (zero? r6))
+    (is (= 1 r7))
+    (is (zero? r8))
+    (is (= 8 r9))))
+
+#?(:cljs (run-tests))
+

--- a/test/asami/wrapgraph_test.cljc
+++ b/test/asami/wrapgraph_test.cljc
@@ -1,0 +1,195 @@
+(ns asami.wrapgraph-test
+  (:require [asami.graph :refer [graph-add graph-transact resolve-pattern count-pattern]]
+     [asami.index :refer [empty-graph]]
+     [asami.wrapgraph :refer [wrap-graph unwrap-graph]]
+     [schema.test :as st :refer [deftest] :refer-macros [deftest]]
+     [clojure.test :as t :refer [testing is run-tests] :refer-macros [testing is run-tests]]))
+
+(t/use-fixtures :once st/validate-schemas)
+
+(def data
+  [[:a :p1 :x]
+   [:a :p1 :y]
+   [:a :p2 :z]
+   [:a :p3 :x]
+   [:b :p1 :x]
+   [:b :p2 :x]
+   [:b :p3 :z]
+   [:c :p4 :t]])
+
+(defn assert-data
+  ([g d]
+   (assert-data g d 1))
+  ([g d tx]
+   (reduce (fn [g [s p o]] (graph-add g s p o tx)) g d)))
+
+(defn unordered-resolve
+  [g pattern]
+  (into #{} (resolve-pattern g pattern)))
+
+(defn do-load-test
+  [g]
+  (let [r1 (unordered-resolve g '[:a ?a ?b])
+        r2 (unordered-resolve g '[?a :p2 ?b])
+        r3 (unordered-resolve g '[:a :p1 ?a])
+        r4 (unordered-resolve g '[?a :p2 :z])
+        r5 (unordered-resolve g '[:a ?a :x])
+        r6 (unordered-resolve g '[:a :p4 ?a])
+        r6' (unordered-resolve g '[:a :p3 ?a])
+        r7 (unordered-resolve g '[:a :p1 :x])
+        r8 (unordered-resolve g '[:a :p1 :b])
+        r9 (unordered-resolve g '[?a ?b ?c])]
+    (is (= #{[:p1 :x]
+             [:p1 :y]
+             [:p2 :z]
+             [:p3 :x]} r1))
+    (is (= #{[:a :z]
+             [:b :x]} r2))
+    (is (= #{[:x]
+             [:y]} r3))
+    (is (= #{[:a]} r4))
+    (is (= #{[:p1]
+             [:p3]} r5))
+    (is (empty? r6))
+    (is (= #{[:x]} r6'))
+    (is (= #{[]} r7))
+    (is (empty? r8))
+    (is (= (into #{} data) r9))))
+
+(deftest test-wrap-empty
+  (do-load-test (assert-data (wrap-graph empty-graph) data)))
+
+(deftest test-wrap-full
+  (do-load-test (wrap-graph (assert-data empty-graph data))))
+
+(deftest test-wrap-insert
+  (->> (take 4 data)
+       (assert-data empty-graph)
+       wrap-graph
+       (#(assert-data % (drop 4 data)))
+       do-load-test))
+
+(deftest test-wrap-2insert
+  (->> (take 4 data)
+       (assert-data empty-graph)
+       wrap-graph
+       (#(assert-data % (take 2 (drop 4 data))))
+       (#(assert-data % (drop 6 data)))
+       do-load-test))
+
+(defn do-test-count [g]
+  (let [r1 (count-pattern g '[:a ?a ?b])
+        r2 (count-pattern g '[?a :p2 ?b])
+        r3 (count-pattern g '[:a :p1 ?a])
+        r4 (count-pattern g '[?a :p2 :z])
+        r5 (count-pattern g '[:a ?a :x])
+        r6 (count-pattern g '[:a :p4 ?a])
+        r7 (count-pattern g '[:a :p1 :x])
+        r8 (count-pattern g '[:a :p1 :b])
+        r9 (count-pattern g '[?a ?b ?c])]
+    (is (= 4 r1))
+    (is (= 2 r2))
+    (is (= 2 r3))
+    (is (= 1 r4))
+    (is (= 2 r5))
+    (is (zero? r6))
+    (is (= 1 r7))
+    (is (zero? r8))
+    (is (= 8 r9))))
+
+(deftest test-count-wrap-empty
+  (do-test-count (assert-data (wrap-graph empty-graph) data)))
+
+(deftest test-count-wrap-full
+  (do-test-count (wrap-graph (assert-data empty-graph data))))
+
+(deftest test-count-wrap-insert
+  (->> (take 4 data)
+       (assert-data empty-graph)
+       wrap-graph
+       (#(assert-data % (drop 4 data)))
+       do-test-count))
+
+(deftest test-count-wrap-2insert
+  (->> (take 4 data)
+       (assert-data empty-graph)
+       wrap-graph
+       (#(assert-data % (take 2 (drop 4 data))))
+       (#(assert-data % (drop 6 data)))
+       do-test-count))
+
+(deftest test-delete
+  (let [g' (wrap-graph (assert-data empty-graph data))
+        g (graph-transact g' 2 [] [[:a :p2 :z] [:c :p4 :t]])
+        r1 (unordered-resolve g '[:a ?a ?b])
+        r2 (unordered-resolve g '[?a :p2 ?b])
+        r3 (unordered-resolve g '[:a :p1 ?a])
+        r4 (unordered-resolve g '[?a :p2 :z])
+        r5 (unordered-resolve g '[:a ?a :x])
+        r6 (unordered-resolve g '[:a :p4 ?a])
+        r6' (unordered-resolve g '[:a :p3 ?a])
+        r7 (unordered-resolve g '[:a :p1 :x])
+        r8 (unordered-resolve g '[:a :p1 :b])
+        r9 (unordered-resolve g '[?a ?b ?c])]
+    (is (= #{[:p1 :x]
+             [:p1 :y]
+             [:p3 :x]} r1))
+    (is (= #{[:b :x]} r2))
+    (is (= #{[:x]
+             [:y]} r3))
+    (is (empty? r4))
+    (is (= #{[:p1]
+             [:p3]} r5))
+    (is (empty? r6))
+    (is (= #{[:x]} r6'))
+    (is (= #{[]} r7))
+    (is (empty? r8))
+    (is (= (into #{} (remove #{[:a :p2 :z] [:c :p4 :t]} data)) r9))))
+
+(deftest test-change
+  (let [g' (wrap-graph (assert-data empty-graph data))
+        g (graph-transact g' 2 [[:a :p3 :z] [:c :p2 :u]] [[:a :p2 :z] [:c :p4 :t]])
+        r1 (unordered-resolve g '[:a ?a ?b])
+        r2 (unordered-resolve g '[?a :p2 ?b])
+        r3 (unordered-resolve g '[:a :p1 ?a])
+        r4 (unordered-resolve g '[?a :p2 :z])
+        r5 (unordered-resolve g '[:a ?a :x])
+        r6 (unordered-resolve g '[:a :p4 ?a])
+        r6' (unordered-resolve g '[:a :p3 ?a])
+        r7 (unordered-resolve g '[:a :p1 :x])
+        r8 (unordered-resolve g '[:a :p1 :b])
+        r9 (unordered-resolve g '[?a ?b ?c])]
+    (is (= #{[:p1 :x]
+             [:p1 :y]
+             [:p3 :z]
+             [:p3 :x]} r1))
+    (is (= #{[:b :x] [:c :u]} r2))
+    (is (= #{[:x]
+             [:y]} r3))
+    (is (empty? r4))
+    (is (= #{[:p1]
+             [:p3]} r5))
+    (is (empty? r6))
+    (is (= #{[:x] [:z]} r6'))
+    (is (= #{[]} r7))
+    (is (empty? r8))
+    (is (= (->> data
+                (remove #{[:a :p2 :z] [:c :p4 :t]})
+                (concat [[:a :p3 :z] [:c :p2 :u]])
+                (into #{}))
+           r9))))
+(deftest test-change
+  (let [g' (wrap-graph (assert-data empty-graph data))
+        g (graph-transact g' 2 [[:a :p3 :z] [:c :p2 :u]] [[:a :p2 :z] [:c :p4 :t]])
+        gu (unwrap-graph g 2)
+        r (unordered-resolve g '[?a ?b ?c])
+        ru (unordered-resolve gu '[?a ?b ?c])
+        expected (->> data
+                      (remove #{[:a :p2 :z] [:c :p4 :t]})
+                      (concat [[:a :p3 :z] [:c :p2 :u]])
+                      (into #{}))]
+    (is (= expected r))
+    (is (= expected ru))))
+
+#?(:cljs (run-tests))
+


### PR DESCRIPTION
This remove the OSP index from the in-memory version, and introduces wrapped graphs, for use in `with`