### PR TITLE
Add type hint to asami.durable.common-utils/get-directory

### DIFF
--- a/src/asami/durable/common_utils.cljc
+++ b/src/asami/durable/common_utils.cljc
@@ -13,7 +13,7 @@
 (def ^:const directory-env "ASAMI_BASE_DIR")
 
 #?(:clj
-   (defn get-directory
+   (defn ^File get-directory
      ([name] (get-directory name true))
      ([name test?]
       (let [[root & path-elements] (string/split name #"/")]


### PR DESCRIPTION
When trying to use asami in Graalvm I get a reflection error in https://github.com/quoll/asami/blob/main/src/asami/durable/flat_file.clj#L329. Adding the type hint fixes the issue.