### PR TITLE
Fix PrivilegedAction proxy signature

### DIFF
--- a/src/asami/durable/block/file/voodoo.clj
+++ b/src/asami/durable/block/file/voodoo.clj
@@ -10,7 +10,7 @@
   (when obj
     (AccessController/doPrivileged
      (proxy [PrivilegedAction] []
-       (run [_]
+       (run []
          (try
            (let [get-cleaner-method (.getMethod (class obj) "cleaner" (make-array Class 0))
                  _ (.setAccessible get-cleaner-method true)


### PR DESCRIPTION
PrivilegedAction.run() is a 0-arity and proxy methods don't take a `this` like protocol/reify functions do.